### PR TITLE
Set proper connection for Redis

### DIFF
--- a/src/main/kotlin/no/uio/bedreflyt/api/config/CacheConfig.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/api/config/CacheConfig.kt
@@ -1,9 +1,12 @@
 package no.uio.bedreflyt.api.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
@@ -11,6 +14,19 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 @EnableCaching
 open class CacheConfig {
+
+    @Bean
+    open fun redisConnectionFactory(
+        @Value("\${spring.redis.host:localhost}") host: String,
+        @Value("\${spring.redis.port:6379}") port: Int
+    ): RedisConnectionFactory {
+        val configuration = RedisStandaloneConfiguration(host, port)
+
+        // Add this logging to debug the connection values
+        println("Redis connecting to: $host:$port")
+
+        return LettuceConnectionFactory(configuration)
+    }
 
     @Bean
     open fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,8 @@ org.slf4j.simpleLogger.logFile=System.out
 
 spring.redis.host=${CACHE_HOST:localhost}
 spring.redis.port=${CACHE_PORT:6379}
+spring.redis.database=${CACHE_DATABASE:0}
+spring.redis.timeout=${CACHE_TIMEOUT:2000}ms
 
 spring.mvc.async.request-timeout=-1
 spring.datasource.hikari.maximum-pool-size=50


### PR DESCRIPTION
This pull request introduces Redis configuration to the application by adding a connection factory and updating the application properties. The changes ensure that Redis can be used for caching with customizable host, port, database, and timeout settings.

### Redis Configuration:

* [`src/main/kotlin/no/uio/bedreflyt/api/config/CacheConfig.kt`]: Added a `redisConnectionFactory` bean to create a `RedisConnectionFactory` using `RedisStandaloneConfiguration`. This includes logging the host and port for debugging purposes.
* [`src/main/resources/application.properties`]: Added new properties for `spring.redis.database` and `spring.redis.timeout` to allow configuration of the Redis database index and connection timeout. 

### Dependency Imports:

* [`src/main/kotlin/no/uio/bedreflyt/api/config/CacheConfig.kt`]: Imported necessary classes for Redis configuration, including `RedisStandaloneConfiguration`, `LettuceConnectionFactory`, and `@Value` for property injection.